### PR TITLE
Fix `BaseUser#can` & `BaseUser#hasPermission` argument

### DIFF
--- a/types/foundry/common/documents/user.d.ts
+++ b/types/foundry/common/documents/user.d.ts
@@ -34,7 +34,7 @@ export default class BaseUser<TCharacter extends BaseActor<null> = BaseActor<nul
      * @param action The action to test
      * @return Does the user have the ability to perform this action?
      */
-    can(action: UserAction): boolean;
+    can(action: UserPermissionString | UserRole | UserRoleName): boolean;
 
     getUserLevel(user: this): DocumentOwnershipLevel;
 
@@ -43,7 +43,7 @@ export default class BaseUser<TCharacter extends BaseActor<null> = BaseActor<nul
      * @param permission The permission name from USER_PERMISSIONS to test
      * @return Does the user have at least this permission
      */
-    hasPermission(permission: UserPermission): boolean;
+    hasPermission(permission: UserPermissionString): boolean;
 
     /**
      * Test whether the User has at least the permission level of a certain role


### PR DESCRIPTION
I am not sure what was going on there, maybe it is something from an old version, but they were off the mark.