### PR TITLE
Fix `ClientBaseActor#apps` index being number

### DIFF
--- a/types/foundry/client/data/documents/client-base-mixes.d.ts
+++ b/types/foundry/client/data/documents/client-base-mixes.d.ts
@@ -1255,7 +1255,7 @@ export class ClientBaseActor<TParent extends CanvasBaseToken<ClientBaseScene | n
      * Application in this object will have its render method called by {@link Document#render}.
      * @see {@link Document#render}
      */
-    apps: { [K in number]?: Application | ApplicationV2 };
+    apps: { [K in string]?: Application | ApplicationV2 };
 
     constructor(data: object, context?: DocumentConstructionContext<TParent>);
 


### PR DESCRIPTION
Foundry declares it as a `Record<string,Application|ApplicationV2>`