### PR TITLE
Add argument to `SceneControlTool#onClick` if toggle

### DIFF
--- a/types/foundry/client/apps/hud/controls.d.ts
+++ b/types/foundry/client/apps/hud/controls.d.ts
@@ -38,18 +38,26 @@ declare class SceneControls extends Application {
     override activateListeners(html: JQuery): void;
 }
 
-declare interface SceneControlTool {
+declare type SceneControlTool = {
     name: string;
     title: string;
     icon: string;
     visible: boolean;
-    toggle?: boolean;
     active?: boolean;
     button?: boolean;
-    onClick?: () => void;
     /** Configuration for rendering the tool's toolclip. */
     toolclip?: ToolclipConfiguration;
-}
+} & (
+    | {
+          toggle?: false;
+          onClick?: () => void;
+      }
+    | {
+          toggle: true;
+          onClick?: (active: boolean) => void;
+      }
+);
+
 
 declare interface SceneControl {
     name: string;


### PR DESCRIPTION
When `SceneControlTool` is a toggle, its `onClick` callback receives a `boolean` argument indicating its current toggle state.

I dunno if there is a better solution to do it, i did it the way i knew how to make it work which required changing it to a type instead of an interface.