### PR TITLE
Change `UserActivity` interface into `ActivityData`

### DIFF
--- a/types/foundry/client/av/index.d.ts
+++ b/types/foundry/client/av/index.d.ts
@@ -1,0 +1,1 @@
+import "./setting.d.ts";

--- a/types/foundry/client/av/setting.d.ts
+++ b/types/foundry/client/av/setting.d.ts
@@ -1,0 +1,12 @@
+export {};
+
+declare global {
+    interface AVSettingsData {
+        /**  Whether this user has muted themselves. */
+        muted?: boolean;
+        /** Whether this user has hidden their video. */
+        hidde?: boolean;
+        /**  Whether the user is broadcasting audio. */
+        speaking?: boolean;
+    }
+}

--- a/types/foundry/client/data/documents/user.d.ts
+++ b/types/foundry/client/data/documents/user.d.ts
@@ -66,7 +66,7 @@ declare global {
          * @param activityData.sceneId The id of the Scene currently being viewed by the User
          * @param activityData.targets An id of Token ids which are targeted by the User
          */
-        broadcastActivity(activityData?: UserActivity): void;
+        broadcastActivity(activityData?: ActivityData): void;
 
         /**
          * Get an Array of Macro Entities on this User's Hotbar by page
@@ -89,13 +89,32 @@ declare global {
         protected override _onDelete(options: DatabaseDeleteOperation<null>, userId: string): void;
     }
 
-    interface UserActivity {
-        cursor?: object;
-        focus?: boolean;
-        ping?: boolean;
-        ruler?: string;
-        sceneId?: string;
-        target?: string[];
+    interface PingData {
+        /** Pulls all connected clients' views to the pinged coordinates. (default: false) */
+        pull?: boolean;
+        /** The ping style, see CONFIG.Canvas.pings. */
+        style: string;
+        /** The ID of the scene that was pinged. */
+        scene: string;
+        /** The zoom level at which the ping was made. */
+        zoom: number;
+    }
+
+    interface ActivityData {
+        /** The ID of the scene that the user is viewing. */
+        sceneId?: string | null;
+        /** The position of the user's cursor. */
+        cursor?: Point;
+        /** The state of the user's ruler, if they are currently using one. */
+        ruler?: RulerData | null;
+        /** The IDs of the tokens the user has targeted in the currently viewed */
+        targets?: string[];
+        /** Whether the user has an open WS connection to the server or not. */
+        active?: boolean;
+        /** Is the user emitting a ping at the cursor coordinates? */
+        ping?: PingData;
+        /** The state of the user's AV settings. */
+        av?: AVSettingsData;
     }
 
     type Active<TUser extends User<Actor<null>>> = TUser & {

--- a/types/foundry/client/index.d.ts
+++ b/types/foundry/client/index.d.ts
@@ -3,6 +3,7 @@ import "handlebars";
 import SHOWDOWN from "showdown";
 import "./apps/index.d.ts";
 import "./config.d.ts";
+import "./av/index.d.ts";
 import "./core/index.d.ts";
 import "./data/index.d.ts";
 import * as Foundry from "./foundry/index.ts";


### PR DESCRIPTION
Probably something from v11 that wasn't updated, foundry makes no mention of `UserActivity` anymore and in its place uses `ActivityData`.

I have added the related types/files for it but couldn't ffind any definition for `RulerData` anywhere in the foundry code, so i left it as is for you to decide what to do with it.