### PR TITLE
Add `ui.macros` and `Hotbar#locked` getter

### DIFF
--- a/types/foundry/client/apps/hud/hotbar.d.ts
+++ b/types/foundry/client/apps/hud/hotbar.d.ts
@@ -33,6 +33,9 @@ declare global {
 
         static override get defaultOptions(): ApplicationOptions;
 
+        /** Whether the hotbar is locked. */
+        get locked(): boolean
+
         override getData(options?: Record<string, unknown>): {
             page: number;
             macros: TMacro[];

--- a/types/foundry/client/ui/index.d.ts
+++ b/types/foundry/client/ui/index.d.ts
@@ -17,7 +17,7 @@ declare global {
         TChatLog extends ChatLog,
         TCompendiumDirectory extends CompendiumDirectory,
         TCombatTracker extends CombatTracker<Combat | null>,
-        THotbar extends Hotbar,
+        THotbar extends Hotbar
     > {
         actors: TActorDirectory;
         chat: TChatLog;
@@ -32,5 +32,6 @@ declare global {
         windows: Record<number, Application>;
         hotbar: THotbar;
         nav: SceneNavigation;
+        macro: DocumentDirectory<Macro>;
     }
 }

--- a/types/foundry/client/ui/index.d.ts
+++ b/types/foundry/client/ui/index.d.ts
@@ -32,6 +32,6 @@ declare global {
         windows: Record<number, Application>;
         hotbar: THotbar;
         nav: SceneNavigation;
-        macro: DocumentDirectory<Macro>;
+        macros: DocumentDirectory<Macro>;
     }
 }


### PR DESCRIPTION
The `MacroDirectory` was missing from the `ui` global context, i have opted to not create `MacroDirectory` itself and use `DocumentDirectory<Macro>` because it brings nothing extra.

The `Hotbar#locked` getter was missing.