### PR TITLE
Allow the use of string for `ApplicationPosition.width`

### DIFF
--- a/types/foundry/client/apps/app.d.ts
+++ b/types/foundry/client/apps/app.d.ts
@@ -393,7 +393,7 @@ declare global {
     }
 
     interface ApplicationPosition {
-        width?: Maybe<number>;
+        width?: Maybe<string | number>;
         height?: Maybe<string | number>;
         left?: Maybe<number>;
         top?: Maybe<number>;


### PR DESCRIPTION
Otherwise we can't set it to `"auto"` like the height.