### PR TITLE
Add default `get` for `ClientSettingsMap`

### DIFF
--- a/types/foundry/client/core/settings.d.ts
+++ b/types/foundry/client/core/settings.d.ts
@@ -131,6 +131,7 @@ declare global {
         get(key: "core.defaultToken"): SettingConfig & { default: PreCreate<foundry.data.PrototypeTokenSource> };
         get(key: "core.dynamicTokenRingFitMode"): SettingConfig & { default: "grid" | "subject" };
         get(key: "core.notesDisplayToggle"): SettingConfig & { default: boolean };
+        get<TDefault extends unknown>(key: string): SettingConfig & { default: TDefault };
     }
 
     /** A simple interface for World settings storage which imitates the API provided by localStorage */


### PR DESCRIPTION
There is no way to do `game.settings.settings.get` right now other that using the four core settings setup in the types.
