### PR TITLE
Set `FilePicker#broser` target as optional

### DIFF
--- a/types/foundry/client/ui/filepicker.d.ts
+++ b/types/foundry/client/ui/filepicker.d.ts
@@ -76,7 +76,7 @@ declare class FilePicker extends Application<FilePickerOptions> {
      * @param target    The target within the currently active source location.
      * @param options   Browsing options
      */
-    browse(target: string, options?: object): Promise<object>;
+    browse(target?: string, options?: object): Promise<object>;
 
     /**
      * Browse files for a certain directory location


### PR DESCRIPTION
It is optional in foundry