### PR TITLE
Use `PreCreate` instead of `DeepPartial` for `ChatMessage#create`

### DIFF
--- a/types/foundry/client/data/documents/chat-message.d.ts
+++ b/types/foundry/client/data/documents/chat-message.d.ts
@@ -217,7 +217,7 @@ declare global {
         ): Promise<TDocument[] | TDocument | undefined>;
     }
 
-    type ChatMessageCreateData<TDocument extends ChatMessage> = DeepPartial<
+    type ChatMessageCreateData<TDocument extends ChatMessage> = PreCreate<
         Omit<TDocument["_source"], "rolls" | "whisper"> & {
             rolls: (string | RollJSON | Roll)[];
             whisper: (string | User)[];


### PR DESCRIPTION
While it doesn't make much difference it is more accurate to use `PreCreate` instead of `DeepPartial` here.