### PR TITLE
Make `Application#setPosition` argument properties optional

### DIFF
--- a/types/foundry/client/apps/app.d.ts
+++ b/types/foundry/client/apps/app.d.ts
@@ -292,11 +292,11 @@ declare global {
 
         /** Set the application position and store it's new location */
         setPosition(position?: {
-            left: Maybe<number>;
-            top: Maybe<number>;
-            width: Maybe<number>;
-            height: Maybe<number | "auto">;
-            scale: Maybe<number>;
+            left?: Maybe<number>;
+            top?: Maybe<number>;
+            width?: Maybe<number>;
+            height?: Maybe<number | "auto">;
+            scale?: Maybe<number>;
         }): {
             left: Maybe<number>;
             top: Maybe<number>;


### PR DESCRIPTION
Just doing `left: Maybe<number>` isn't enough to make the property optional, typescript will force you to provide it even if it must be `undefined` or `null`.

To make it optional we must mark it with the `?`