### PR TITLE
Change `Symbol.iterator` generator next generic type to any instead of never

### DIFF
--- a/types/foundry/common/utils/iterable-weak-map.d.ts
+++ b/types/foundry/common/utils/iterable-weak-map.d.ts
@@ -53,7 +53,7 @@ export default class IterableWeakMap<K extends WeakKey, V> extends WeakMap<K, V>
     /**
      * Enumerate the entries.
      */
-    [Symbol.iterator](): Generator<[K, V], void, never>;
+    [Symbol.iterator](): Generator<[K, V], void, any>;
 
     /**
      * Enumerate the entries.

--- a/types/foundry/common/utils/iterable-weak-map.d.ts
+++ b/types/foundry/common/utils/iterable-weak-map.d.ts
@@ -58,17 +58,17 @@ export default class IterableWeakMap<K extends WeakKey, V> extends WeakMap<K, V>
     /**
      * Enumerate the entries.
      */
-    entries(): Generator<[K, V], void, never>;
+    entries(): Generator<[K, V], void, any>;
 
     /**
      * Enumerate the keys.
      */
-    keys(): Generator<K, void, never>;
+    keys(): Generator<K, void, any>;
 
     /**
      * Enumerate the values.
      */
-    values(): Generator<V, void, never>;
+    values(): Generator<V, void, any>;
 }
 
 declare global {

--- a/types/foundry/common/utils/iterable-weak-set.d.ts
+++ b/types/foundry/common/utils/iterable-weak-set.d.ts
@@ -16,7 +16,7 @@ export default class IterableWeakSet<T extends WeakKey> extends WeakSet<T> {
     /**
      * Enumerate the values.
      */
-    [Symbol.iterator](): Generator<T, void, never>;
+    [Symbol.iterator](): Generator<T, void, any>;
 
     /**
      * Add a value to the set.

--- a/types/foundry/common/utils/iterable-weak-set.d.ts
+++ b/types/foundry/common/utils/iterable-weak-set.d.ts
@@ -39,7 +39,7 @@ export default class IterableWeakSet<T extends WeakKey> extends WeakSet<T> {
     /**
      * Enumerate the collection.
      */
-    values(): Generator<T, void, never>;
+    values(): Generator<T, void, any>;
 
     /**
      * Clear all values from the set.


### PR DESCRIPTION
Having the `Generator` next type `never` prevents us from iterating over the `Iterable` using `for-of`

> Cannot iterate value because the 'next' method of its iterator expects type 'never', but for-of will always send 'undefined'.

So i changed them to `any` instead