### PR TITLE
Add `null` & `undefined` to default settings

### DIFF
--- a/types/foundry/common/types.d.ts
+++ b/types/foundry/common/types.d.ts
@@ -56,7 +56,7 @@ declare global {
         /** For numeric Types, defines the allowable range */
         range?: this["type"] extends NumberConstructor ? { min: number; max: number; step: number } : never;
         /** The default value */
-        default: number | string | boolean | object | (() => number | string | boolean | object);
+        default: number | string | boolean | object | null | undefined | (() => number | string | boolean | object);
         /** Executes when the value of this Setting changes */
         onChange?: (choice: TChoices extends object ? keyof TChoices : unknown) => void | Promise<void>;
     }


### PR DESCRIPTION
You can use both when setting a default value.