### PR TITLE
Replace `WorldSettingsStorage` with `WorldSettings`

### DIFF
--- a/types/foundry/client/core/settings.d.ts
+++ b/types/foundry/client/core/settings.d.ts
@@ -1,9 +1,9 @@
 export {};
 
 declare global {
-    interface ClientSettingsStorage extends Map<string, Storage | WorldSettingsStorage> {
+    interface ClientSettingsStorage extends Map<string, Storage | WorldSettings> {
         get(key: "client"): Storage;
-        get(key: "world"): WorldSettingsStorage;
+        get(key: "world"): WorldSettings;
     }
 
     /**
@@ -134,12 +134,24 @@ declare global {
         get<TDefault>(key: string): SettingConfig & { default: TDefault };
     }
 
-    /** A simple interface for World settings storage which imitates the API provided by localStorage */
-    class WorldSettingsStorage extends Collection<Setting> {
-        constructor(settings: object);
+    /**
+     * The Collection of Setting documents which exist within the active World.
+     * This collection is accessible as game.settings.storage.get("world")
+     * @extends {WorldCollection}
+     *
+     * @see {@link Setting} The Setting document
+     */
+    class WorldSettings extends WorldCollection<Setting> {
+        /**
+         * Return the Setting document with the given key.
+         * @param key The setting key
+         */
+        getSetting(key: string): Setting;
 
+        /**
+         * Return the serialized value of the world setting as a string
+         * @param key The setting key
+         */
         getItem(key: string): string | null;
-
-        setItem(key: string, value: unknown): void;
     }
 }

--- a/types/foundry/client/data/documents/index.d.ts
+++ b/types/foundry/client/data/documents/index.d.ts
@@ -46,6 +46,7 @@ declare global {
         | Playlist
         | RollTable
         | Scene
+        | Setting
         | User;
 
     type WorldDocumentUUID<T extends WorldDocument = WorldDocument> = `${T["documentName"]}.${string}`;


### PR DESCRIPTION
The class actually exists in foundry and is called `WorldSettings`, also, the `getSetting` method was missing from it.