### PR TITLE
Three small fixes to tours

### DIFF
--- a/types/foundry/client/ui/tour.d.ts
+++ b/types/foundry/client/ui/tour.d.ts
@@ -6,7 +6,7 @@ declare global {
      * @param config           The configuration of the Tour
      */
     class Tour {
-        constructor(config: TourConfig, override: { id?: string; namspace?: string });
+        constructor(config: TourConfig, override?: { id?: string; namspace?: string });
 
         static STATUS: {
             UNSTARTED: "unstarted";

--- a/types/foundry/client/ui/tour.d.ts
+++ b/types/foundry/client/ui/tour.d.ts
@@ -189,7 +189,7 @@ declare global {
         /** A DOM selector which denotes an element to highlight during this step.
          *  If omitted, the step is displayed in the center of the screen. */
         selector?: string;
-        /** Activates a particular sidebar tab. */
+        /** Activates a particular sidebar tab. Only works for `SidebarTour` instances. */
         sidebarTab?: string;
         /** How the tooltip for the step should be displayed relative to the target element.
          *  If omitted, the best direction will be attempted to be auto-selected.

--- a/types/foundry/client/ui/tour.d.ts
+++ b/types/foundry/client/ui/tour.d.ts
@@ -178,6 +178,8 @@ declare global {
         /** A DOM selector which denotes an element to highlight during this step.
          *  If omitted, the step is displayed in the center of the screen. */
         selector?: string;
+        /** Activates a particular sidebar tab. */
+        sidebarTab?: string;
         /** How the tooltip for the step should be displayed relative to the target element.
          *  If omitted, the best direction will be attempted to be auto-selected.
          */

--- a/types/foundry/client/ui/tour.d.ts
+++ b/types/foundry/client/ui/tour.d.ts
@@ -154,6 +154,17 @@ declare global {
         protected _reloadProgress(): void;
     }
 
+    /**
+     * A tour for demonstrating an aspect of Canvas functionality.
+     * Automatically activates a certain canvas layer or tool depending on the needs of the step.
+     */
+    class CanvasTour extends Tour {}
+
+    /**
+     * A Tour subclass for the Sidebar Tour
+     */
+    class SidebarTour extends Tour {}
+
     /** A singleton Tour Collection class responsible for registering and activating Tours, accessible as game.tours */
     class Tours extends Collection {
         /**


### PR DESCRIPTION
## Make the second override object in the `Tour` constructor optional
Foundry doesn't throw errors if you leave it undefined. See definition in Foundry itself:
![image](https://github.com/user-attachments/assets/93f0fa28-43fc-4f9d-9b4c-09f4233fa024)

## Document `TourStep.sidebarTab`
See https://github.com/foundryvtt/foundryvtt/issues/12065

## Add `Tour` subclasses, [`CanvasTour`](https://foundryvtt.com/api/classes/client.CanvasTour.html) and [`SidebarTour`](https://foundryvtt.com/api/classes/client.CanvasTour.html)
These are actually both identical in type to `Tour` in type, but they have unique behaviour when you start them (namely regarding pausing and handling `sidebarTab`).

I've deliberately neglected to add [`SetupTour`](https://foundryvtt.com/api/classes/client.SetupTour.html) since—as far as I know—modules can't interact with this.