### PR TITLE
Implement `ToursManagement` class

### DIFF
--- a/types/foundry/client/ui/tour.d.ts
+++ b/types/foundry/client/ui/tour.d.ts
@@ -228,4 +228,16 @@ declare global {
          */
         suggestedNextTours?: string[];
     }
+
+    /**
+     * A management app for configuring which Tours are available or have been completed.
+     */
+    class ToursManagement extends PackageConfiguration {
+        protected override _prepareCategoryData(): { categories: object[]; total: number };
+        protected override _updateObject(event: Event, formData: Record<string, unknown>): Promise<unknown>;
+        protected override _onResetDefaults(event: Event): Promise<any>;
+
+        /** Handle Control clicks */
+        private _onClickControl(event: MouseEvent): any;
+    }
 }


### PR DESCRIPTION
Implements the [`ToursManagement`](https://foundryvtt.com/api/classes/client.ToursManagement.html) class.

Despite what the documentation says, `_prepareCategoryData().categories` is not a `Map`; it is an `object[]` like every other `PackageConfiguration`. I can't be bothered to report given it's a private method ¯\\\_(ツ)\_/¯