### PR TITLE
v13 slugify use object argument

### DIFF
--- a/types/foundry/common/primitives/string.d.mts
+++ b/types/foundry/common/primitives/string.d.mts
@@ -13,11 +13,11 @@ declare global {
 
         /**
          * Transform any string into an url-viable slug string
-        *  @param [options]             Optional arguments which customize how the slugify operation is performed
-         * @param [options.replacement] The replacement character to separate terms, default is '-'
-         * @param [options.strict]      Replace all non-alphanumeric characters, or allow them? Default false
-         * @param [options.lowercase]   Lowercase the string.
-         * @returns                     The slugified input string
+         * @param options Optional arguments which customize how the slugify operation is performed
+         * @param options.replacement The replacement character to separate terms, default is '-'
+         * @param options.strict Replace all non-alphanumeric characters, or allow them? Default false
+         * @param options.lowercase Lowercase the string.
+         * @returns The slugified input string
          */
         slugify(options?: {replacement?: string, strict?: boolean, lowercase?: boolean}): string
     }

--- a/types/foundry/common/primitives/string.d.mts
+++ b/types/foundry/common/primitives/string.d.mts
@@ -12,11 +12,13 @@ declare global {
         stripScripts(): string;
 
         /**
-         * Transform any string into a url-viable slug string
-         * @param replacement The replacement character to separate terms, default is '-'
-         * @param strict      Replace all non-alphanumeric characters, or allow them? Default false
-         * @return The cleaned slug string
+         * Transform any string into an url-viable slug string
+        *  @param [options]             Optional arguments which customize how the slugify operation is performed
+         * @param [options.replacement] The replacement character to separate terms, default is '-'
+         * @param [options.strict]      Replace all non-alphanumeric characters, or allow them? Default false
+         * @param [options.lowercase]   Lowercase the string.
+         * @returns                     The slugified input string
          */
-        slugify(replacement?: string, strict?: boolean): string;
+        slugify(options?: {replacement?: string, strict?: boolean, lowercase?: boolean}): string
     }
 }


### PR DESCRIPTION
Instead of chained arguments, it uses a single `options` object