### PR TITLE
declare the name property for ClientDocument

### DIFF
--- a/types/foundry/client/documents/abstract/client-document.d.mts
+++ b/types/foundry/client/documents/abstract/client-document.d.mts
@@ -27,6 +27,8 @@ export default function ClientDocumentMixin<TParent extends Document | null, TDo
 ): ConstructorOf<ClientDocument<TParent> & TDocument>;
 
 export class ClientDocument<TParent extends Document | null = Document | null> extends Document<TParent> {
+    declare name: string
+
     readonly apps: Record<string, Application | ApplicationV2>;
 
     static override name: string;


### PR DESCRIPTION
The code of the class itself refer to `this.name` quite a lot without condition which means that it is always expected that a `name` property exists, so i thought i would declare it that way.