### PR TITLE
add missing legacy options argument

### DIFF
--- a/types/foundry/client/applications/api/application.d.mts
+++ b/types/foundry/client/applications/api/application.d.mts
@@ -145,7 +145,7 @@ export default abstract class ApplicationV2<
      *                      ApplicationV1#render signature.
      * @returns A Promise which resolves to the rendered Application instance
      */
-    render(options?: boolean | DeepPartial<TRenderOptions>): Promise<this>;
+     render(options?: boolean | DeepPartial<TRenderOptions>, _options?:DeepPartial<TRenderOptions>): Promise<this>;
 
     /**
      * Modify the provided options passed to a render request.


### PR DESCRIPTION
the argument was defined in the jsdoc but wasn't actually in the definition